### PR TITLE
feat: remove default CPU limits

### DIFF
--- a/charts/archetype/Chart.yaml
+++ b/charts/archetype/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.0.1-alpha.1
+version: 0.0.1-alpha.2
 
 appVersion: 0.0.0
 

--- a/charts/archetype/README.md
+++ b/charts/archetype/README.md
@@ -1,6 +1,6 @@
 # archetype
 
-![Version: 0.0.1-alpha.1](https://img.shields.io/badge/Version-0.0.1--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.0.1-alpha.2](https://img.shields.io/badge/Version-0.0.1--alpha.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 

--- a/charts/archetype/templates/_podtemplate.tpl
+++ b/charts/archetype/templates/_podtemplate.tpl
@@ -37,11 +37,13 @@ Outputs a pod spec for use in different resources.
         name: {{ template "archetype.name" . }}
         resources:
           requests:
-            memory: {{ default .Values.resources.memory .Values.resources.requests.memory }}
-            cpu: {{ default .Values.resources.cpu .Values.resources.requests.cpu }}
+            memory: {{ default .Values.resources.memory .Values.resources.requests.memory | quote }}
+            cpu: {{ default .Values.resources.cpu .Values.resources.requests.cpu | quote }}
           limits:
-            memory: {{ default .Values.resources.memory .Values.resources.limits.memory }}
-            cpu: {{ default .Values.resources.cpu .Values.resources.limits.cpu }}
+            memory: {{ default .Values.resources.memory .Values.resources.limits.memory | quote }}
+            {{- if .Values.resources.limits.cpu }}
+            cpu: {{ .Values.resources.limits.cpu | quote }}
+            {{- end }}
         ports:
         {{- range $portName, $portSpec := .Values.ports }}
           - name: {{ $portName }}


### PR DESCRIPTION
Removes the CPU limits default. CPU can be considered "compressible" and a limit value can negatively impact workload performance.